### PR TITLE
Fix crawler hanging due to threading issue in html2text

### DIFF
--- a/src/v2ex_crawler.py
+++ b/src/v2ex_crawler.py
@@ -53,11 +53,8 @@ class V2EXCrawler:
         self.request_count = 0
         self.rate_limit_delay = 1.0
         
-        # HTML到Markdown转换器
-        self.html_converter = html2text.HTML2Text()
-        self.html_converter.ignore_links = False
-        self.html_converter.ignore_images = False
-        self.html_converter.body_width = 0  # 不限制行宽
+        # HTML to Markdown converter will be created on-demand in the conversion
+        # method to ensure thread safety.
     
     def _get_random_headers(self) -> Dict[str, str]:
         """获取随机请求头"""
@@ -190,8 +187,14 @@ class V2EXCrawler:
             if not html_content or not html_content.strip():
                 return ''
             
+            # To ensure thread safety, create a new instance for each call.
+            html_converter = html2text.HTML2Text()
+            html_converter.ignore_links = False
+            html_converter.ignore_images = False
+            html_converter.body_width = 0  # Do not wrap lines.
+
             # 使用html2text转换
-            markdown_content = self.html_converter.handle(html_content)
+            markdown_content = html_converter.handle(html_content)
             
             # 清理多余的空行
             lines = markdown_content.split('\n')


### PR DESCRIPTION
I noticed the crawler process was hanging after completing all scraping tasks in the GitHub Actions environment.

I believe this was caused by a race condition or deadlock in the `html2text` library. A single instance of the `HTML2Text` converter was being shared across multiple threads in the `ThreadPoolExecutor`, which is not a thread-safe operation. The "HTML转Markdown失败" warnings I found in the logs supported this hypothesis.

I have fixed this by creating a new `HTML2Text` instance within the `_html_to_markdown` method for each call. This ensures that each thread has its own separate instance, preventing any concurrency problems.